### PR TITLE
fix typo in /.config/.env.example

### DIFF
--- a/.config/.env.example
+++ b/.config/.env.example
@@ -6,7 +6,7 @@ PORT=3010
 DBHOST=localhost
 DBUSER=bancho
 DBPASS=
-DBNAME=bancho
+DBNAME=banchopy
 
 # Bancho.py local preffered
 APIURL=https://api.osunolimits.dev
@@ -33,7 +33,7 @@ MAX_THREAS=20
 TIMEOUT_MS=60000
 
 # Redis Cache
-REDISHOST=locahost
+REDISHOST=localhost
 REDISPORT=6379
 REDISDB=0
 REDISUSER=default


### PR DESCRIPTION
the file had the REDISHOST as locahost, meanwhile it should be localhost. also changed the db name to banchopy, as that's what the unedited bancho.py install uses