### PR TITLE
Prevent leading/trailing whitespace in usernames

### DIFF
--- a/src/main/java/dev/osunolimits/routes/post/HandleNameChange.java
+++ b/src/main/java/dev/osunolimits/routes/post/HandleNameChange.java
@@ -36,7 +36,7 @@ public class HandleNameChange extends Shiina {
 
         String newName = req.queryParams("newname");
         String newSafeName = newName.toLowerCase().replaceAll(" ", "_");
-        if(newName == null || newName.isEmpty()) {
+        if(newName == null || newName.isEmpty() || !newName.equals(newName.trim())) {
             return redirect(res, shiina, "/settings?error=Invalid name");
         }
 

--- a/src/main/java/dev/osunolimits/routes/post/HandleRegister.java
+++ b/src/main/java/dev/osunolimits/routes/post/HandleRegister.java
@@ -47,6 +47,11 @@ public class HandleRegister extends Shiina {
             shiina.data.put("error", "Missing required fields");
             return renderTemplate("register.html", shiina, res, req);
         }
+        
+        if (!username.equals(username.trim())) {
+            shiina.data.put("error", "Username cannot start or end with whitespace");
+            return renderTemplate("register.html", shiina, res, req);
+        }
     
         // Check if the username or email already exists in the database
         String emailCheckSql = "SELECT `id` FROM `users` WHERE `email` = ?";


### PR DESCRIPTION
Fixes a vulnerability which allows people to change or register their username to appear the same as others by using a whitespace character at either the start or end of a userrname