### PR TITLE
fix typos

### DIFF
--- a/.config/.env.example
+++ b/.config/.env.example
@@ -23,7 +23,7 @@ AVATARFOLDER=/home/bancho.py/.data/avatars/
 MAXFILESIZE=1 # in MB
 MAXREQUESTSIZE=2 # in MB
 
-# Clouflare Captcha
+# Cloudflare Captcha
 TURNSTILE_KEY=
 TURNSTILE_SECRET=
 
@@ -34,7 +34,7 @@ TIMEOUT=3000
 # WebServer Tuning
 TEMPLATE_UPDATE_DELAY=30000
 MIN_THREADS=10
-MAX_THREAS=20
+MAX_THREADS=20
 TIMEOUT_MS=60000
 
 # Redis Cache

--- a/src/main/java/dev/osunolimits/main/Init.java
+++ b/src/main/java/dev/osunolimits/main/Init.java
@@ -34,7 +34,7 @@ public class Init {
 
         try {
             webServer.setThreadPool(Integer.parseInt(App.env.get("MIN_THREADS")),
-                    Integer.parseInt(App.env.get("MAX_THREAS")), Integer.parseInt(App.env.get("TIMEOUT_MS")));
+                    Integer.parseInt(App.env.get("MAX_THREADS")), Integer.parseInt(App.env.get("TIMEOUT_MS")));
         } catch (Exception e) {
             log.warn("Failed to set WebServer Thread Configuration");
             System.exit(1);


### PR DESCRIPTION
fixes simple typos in .env.example and in Init.java (i dont know why it changed docs)