### PR TITLE
feat: instant PP updates via Redis PubSub

### DIFF
--- a/src/main/java/dev/osunolimits/main/App.java
+++ b/src/main/java/dev/osunolimits/main/App.java
@@ -34,6 +34,7 @@ import dev.osunolimits.modules.utils.GroupRegistry;
 import dev.osunolimits.modules.utils.ShiinaAchievementsSorter;
 import dev.osunolimits.modules.utils.ThemeLoader;
 import dev.osunolimits.modules.utils.UserInfoCache;
+import dev.osunolimits.modules.pubsubs.PPUpdateSubscriber;
 import dev.osunolimits.plugins.PluginLoader;
 import dev.osunolimits.plugins.ShiinaRegistry;
 import dev.osunolimits.routes.ap.api.PubSubHandler;
@@ -172,6 +173,7 @@ public class App {
         StartupTaskRunner.register(new StartupLogConfigTask());
         StartupTaskRunner.register(new StartupDatabaseTask());
         StartupTaskRunner.register(new StartupSetupRedisTask());
+        PPUpdateSubscriber.start();
         StartupTaskRunner.register(new AutorunSQLTask());
 
         StartupTaskRunner.register(new StartupInitCustomizations());

--- a/src/main/java/dev/osunolimits/modules/CacheInvalidator.java
+++ b/src/main/java/dev/osunolimits/modules/CacheInvalidator.java
@@ -1,0 +1,45 @@
+package dev.osunolimits.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CacheInvalidator {
+    private static final Logger log = LoggerFactory.getLogger("CacheInvalidator");
+
+    public static void clearUserCache() {
+        clearCacheDirectory(".cache/users");
+    }
+
+    public static void clearLeaderboardCache() {
+        clearCacheDirectory(".cache/leaderboard");
+    }
+
+    public static void clearAllApiCaches() {
+        clearUserCache();
+        clearLeaderboardCache();
+    }
+
+    private static void clearCacheDirectory(String directory) {
+        Path cachePath = Paths.get(directory);
+        if (!Files.exists(cachePath)) {
+            return;
+        }
+
+        try {
+            Files.walk(cachePath)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+            log.debug("Cleared cache directory: {}", directory);
+        } catch (IOException e) {
+            log.error("Failed to clear cache directory: {}", directory, e);
+        }
+    }
+}

--- a/src/main/java/dev/osunolimits/modules/pubsubs/PPUpdateSubscriber.java
+++ b/src/main/java/dev/osunolimits/modules/pubsubs/PPUpdateSubscriber.java
@@ -1,0 +1,91 @@
+package dev.osunolimits.modules.pubsubs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+import dev.osunolimits.main.App;
+import dev.osunolimits.modules.CacheInvalidator;
+import dev.osunolimits.modules.pubsubs.PubSubModels.PPUpdateMessage;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPubSub;
+
+public class PPUpdateSubscriber {
+    private static final Logger log = LoggerFactory.getLogger("PPUpdateSubscriber");
+    private static final Gson gson = new Gson();
+    private static final String CHANNEL = "shiina:pp_update";
+
+    public static void start() {
+        Thread subscriberThread = new Thread(() -> {
+            while (true) {
+                try {
+                    subscribeToChannel();
+                } catch (Exception e) {
+                    log.error("PubSub connection error, reconnecting in 5 seconds...", e);
+                    try {
+                        Thread.sleep(5000);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        log.info("PubSub subscriber thread interrupted, stopping.");
+                        break;
+                    }
+                }
+            }
+        });
+        subscriberThread.setName("PPUpdateSubscriber");
+        subscriberThread.setDaemon(true);
+        subscriberThread.start();
+        log.info("Started PP Update subscriber on channel: {}", CHANNEL);
+    }
+
+    private static void subscribeToChannel() {
+        HostAndPort hostAndPort = new HostAndPort(
+            App.env.get("REDISHOST"),
+            Integer.parseInt(App.env.get("REDISPORT"))
+        );
+
+        DefaultJedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+            .connectionTimeoutMillis(Integer.parseInt(App.env.get("REDISTIMEOUT")))
+            .database(Integer.parseInt(App.env.get("REDISDB")))
+            .password(App.env.get("REDISPASS"))
+            .user(App.env.get("REDISUSER"))
+            .build();
+
+        try (Jedis jedis = new Jedis(hostAndPort, clientConfig)) {
+            jedis.subscribe(new JedisPubSub() {
+                @Override
+                public void onMessage(String channel, String message) {
+                    handlePPUpdate(message);
+                }
+
+                @Override
+                public void onSubscribe(String channel, int subscribedChannels) {
+                    log.info("Subscribed to channel: {}", channel);
+                }
+
+                @Override
+                public void onUnsubscribe(String channel, int subscribedChannels) {
+                    log.info("Unsubscribed from channel: {}", channel);
+                }
+            }, CHANNEL);
+        }
+    }
+
+    private static void handlePPUpdate(String message) {
+        try {
+            PPUpdateMessage ppUpdate = gson.fromJson(message, PPUpdateMessage.class);
+            log.debug("Received PP update: user_id={}, mode={}, pp={}",
+                ppUpdate.user_id, ppUpdate.mode, ppUpdate.pp);
+
+            // Clear API caches to force fresh data on next request
+            CacheInvalidator.clearAllApiCaches();
+
+            log.debug("Cache invalidated for PP update");
+        } catch (Exception e) {
+            log.error("Failed to process PP update message: {}", message, e);
+        }
+    }
+}

--- a/src/main/java/dev/osunolimits/modules/pubsubs/PubSubModels.java
+++ b/src/main/java/dev/osunolimits/modules/pubsubs/PubSubModels.java
@@ -60,9 +60,16 @@ public class PubSubModels {
         public String country;
     }
 
-    @Data 
+    @Data
     public static class NameChangeInput {
         public int id;
         public String name;
+    }
+
+    @Data
+    public static class PPUpdateMessage {
+        public int user_id;
+        public int mode;
+        public int pp;
     }
 }


### PR DESCRIPTION
Fix the slow updating of PP count on leaderboards and user profiles by using redis PubSubs to invalidate the cache whenever a player's pp updates